### PR TITLE
hotfix/fix-version-handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ cmake_minimum_required(VERSION 3.5.0)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/helpers.cmake)
 
 set(MSG_PREFIX "etl |")
-determine_version_with_git(${GIT_DIR_LOOKUP_POLICY})
+# NOTE: note used because we do not use the semantic versioning
+# determine_version_with_git(${GIT_DIR_LOOKUP_POLICY})
 if(NOT ETL_VERSION)
     determine_version_with_file("version.txt")
 endif()


### PR DESCRIPTION
We are not using semantic versioning because we are a fork and want to connect our versions with the upstream. That is why the CMake project version should be deduced from the file which holds the version of the upstream.